### PR TITLE
feat: 멘토 보관함 페이지 구현 및 API 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import PlaceholderPage from './static/PlaceholderPage';
 import MyPage from './pages/MyPage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import MentorFeedbackPage from './pages/mentor/FeedbackPage';
+import MentorArchivePage from './pages/mentor/ArchivePage';
 import AssignmentManagementPage from './pages/mentor/AssignmentManagementPage';
 import LearningMaterialPage from './pages/mentor/LearningMaterialPage';
 import ColumnWritePage from './pages/mentor/ColumnWritePage';
@@ -33,8 +34,8 @@ function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <NotificationToasts />
       <BrowserRouter>
+        <NotificationToasts />
         <Routes>
           {/* 루트는 메인으로 리다이렉트 */}
           <Route path="/" element={<Navigate to="/main" replace />} />
@@ -69,7 +70,7 @@ function App() {
               <Route path="column" element={<ColumnWritePage />} />
             </Route>
             <Route path="report" element={<MentorReportPage />} />
-            <Route path="archive" element={<PlaceholderPage name="보관함" />} />
+            <Route path="archive" element={<MentorArchivePage />} />
             <Route path="my-page" element={<MyPage />} />
           </Route>
         </Routes>

--- a/src/api/mentor.ts
+++ b/src/api/mentor.ts
@@ -80,6 +80,39 @@ export async function createMentorReport(
 }
 
 /**
+ * 멘티 과제, 피드백 조회 (보관함용)
+ * GET /mentor/mentee/{menteeId}/task-feedback
+ */
+export interface MenteeTaskFeedbackResponse {
+  tasks: Array<{
+    taskId: number;
+    title: string;
+    subject: string;
+    createdAt: string;
+    feedbackStatus: 'PENDING' | 'COMPLETED';
+    images: Array<{
+      url: string;
+      name: string;
+      sequence: number;
+    }>;
+    feedback?: {
+      feedbackId: number;
+      summary: string;
+      comment: string;
+    };
+  }>;
+}
+
+export async function getMenteeTaskFeedback(
+  menteeId: number
+): Promise<MenteeTaskFeedbackResponse> {
+  const response = await axios.get<MenteeTaskFeedbackResponse>(
+    `/mentor/mentee/${menteeId}/task-feedback`
+  );
+  return response.data;
+}
+
+/**
  * 멘티에게 과제 할당 (PDF 포함).
  * POST /tasks/mentor/assignment
  * - request: 과제 정보 JSON (필수)

--- a/src/components/feature/dashboard/SubmittedTaskModal.tsx
+++ b/src/components/feature/dashboard/SubmittedTaskModal.tsx
@@ -1,0 +1,146 @@
+interface SubmittedTaskModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  task: {
+    id: number;
+    title: string;
+    subject: string;
+    date: string;
+    studyTime: string;
+    images: string[];
+    comment?: string;
+    feedback?: {
+      summary: string;
+      detail: string;
+    };
+  };
+}
+
+const SubmittedTaskModal = ({ isOpen, onClose, task }: SubmittedTaskModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white rounded-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+        {/* 헤더 */}
+        <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between">
+          <h2 className="text-lg font-bold text-gray-900">제출 과제 조회</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* 내용 */}
+        <div className="p-6 space-y-6">
+          {/* 과목 태그 */}
+          <div>
+            <span className="inline-block px-3 py-1 bg-green-100 text-green-600 text-xs font-semibold rounded-full">
+              {task.subject}
+            </span>
+            <p className="text-sm text-gray-500 mt-1">{task.date}</p>
+          </div>
+
+          {/* 과제명 */}
+          <div>
+            <h3 className="text-base font-bold text-gray-900">{task.title}</h3>
+          </div>
+
+          {/* 공부 시간 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              공부한 시간 *
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                value={task.studyTime.split('시간')[0]}
+                readOnly
+                className="w-20 px-3 py-2 border border-gray-300 rounded-lg text-center bg-gray-50"
+              />
+              <span className="text-sm text-gray-600">시간</span>
+              <input
+                type="number"
+                value={task.studyTime.split('시간')[1]?.replace('분', '').trim() || '0'}
+                readOnly
+                className="w-20 px-3 py-2 border border-gray-300 rounded-lg text-center bg-gray-50"
+              />
+              <span className="text-sm text-gray-600">분</span>
+            </div>
+          </div>
+
+          {/* 학습 인증샷 */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              학습 인증샷 *
+            </label>
+            <div className="space-y-3">
+              {task.images.map((image, index) => (
+                <div key={index} className="rounded-lg overflow-hidden border border-gray-200">
+                  <img
+                    src={image}
+                    alt={`학습 인증샷 ${index + 1}`}
+                    className="w-full h-auto"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 질문 코멘트 */}
+          {task.comment && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                질문 코멘트
+              </label>
+              <div className="p-4 bg-gray-50 rounded-lg text-sm text-gray-700 whitespace-pre-wrap">
+                {task.comment}
+              </div>
+            </div>
+          )}
+
+          {/* 피드백 */}
+          {task.feedback && (
+            <>
+              {/* 피드백 요약 */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  피드백 요약
+                </label>
+                <div className="p-4 bg-purple-50 rounded-lg text-sm text-gray-700 whitespace-pre-wrap">
+                  {task.feedback.summary}
+                </div>
+              </div>
+
+              {/* 피드백 상세 */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  피드백 상세
+                </label>
+                <div className="p-4 bg-purple-50 rounded-lg text-sm text-gray-700 whitespace-pre-wrap">
+                  {task.feedback.detail}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* 푸터 */}
+        <div className="sticky bottom-0 bg-white border-t border-gray-200 px-6 py-4">
+          <button
+            onClick={onClose}
+            className="w-full py-3 bg-purple-600 text-white font-medium rounded-lg hover:bg-purple-700 transition-colors"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SubmittedTaskModal;

--- a/src/hooks/useMenteeFeedbacks.ts
+++ b/src/hooks/useMenteeFeedbacks.ts
@@ -1,0 +1,69 @@
+import { useQuery } from '@tanstack/react-query';
+import axios from '../libs/axios';
+
+const FEEDBACKS_QUERY_KEY = ['menteeFeedbacks'] as const;
+const UNREAD_COUNT_QUERY_KEY = ['unreadFeedbackCount'] as const;
+
+interface FeedbackItem {
+  feedbackId: number;
+  taskTitle: string;
+  subject: string;
+  createdAt: string;
+  summary: string;
+  comment: string;
+  isRead: boolean;
+}
+
+/**
+ * 멘티 피드백 목록 조회 훅
+ * GET /api/v1/feedback/mentee/feedbacks
+ */
+export function useMenteeFeedbacks() {
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: FEEDBACKS_QUERY_KEY,
+    queryFn: async () => {
+      try {
+        const response = await axios.get<{ feedbacks: FeedbackItem[] }>('/feedback/mentee/feedbacks');
+        return response.data.feedbacks || [];
+      } catch (err) {
+        console.error('Failed to fetch feedbacks:', err);
+        return [];
+      }
+    },
+  });
+
+  return {
+    feedbacks: data ?? [],
+    isLoading,
+    isError,
+    error: error ?? null,
+    refetch,
+  };
+}
+
+/**
+ * 안 읽은 피드백 개수 조회 훅
+ * GET /api/v1/feedback/mentee/unread-count
+ */
+export function useUnreadFeedbackCount() {
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: UNREAD_COUNT_QUERY_KEY,
+    queryFn: async () => {
+      try {
+        const response = await axios.get<{ count: number }>('/feedback/mentee/unread-count');
+        return response.data.count || 0;
+      } catch (err) {
+        console.error('Failed to fetch unread feedback count:', err);
+        return 0;
+      }
+    },
+  });
+
+  return {
+    count: data ?? 0,
+    isLoading,
+    isError,
+    error: error ?? null,
+    refetch,
+  };
+}

--- a/src/hooks/useMenteeTasks.ts
+++ b/src/hooks/useMenteeTasks.ts
@@ -1,0 +1,140 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import axios from '../libs/axios';
+
+const QUERY_KEY_PREFIX = ['menteeTasks'] as const;
+
+interface TaskItem {
+  taskId: number;
+  title: string;
+  subject: string;
+  isCompleted: boolean;
+  studyTime?: number;
+  date: string;
+}
+
+/**
+ * 멘티 과제 목록 조회 훅
+ * GET /api/v1/tasks/mentee/list?date=YYYY-MM-DD
+ */
+export function useMenteeTasks(date: string) {
+  const { data, isLoading, isError, error, refetch } = useQuery({
+    queryKey: [...QUERY_KEY_PREFIX, date],
+    queryFn: async () => {
+      try {
+        const response = await axios.get<{ tasks: TaskItem[] }>('/tasks/mentee/list', {
+          params: { date }
+        });
+        return response.data.tasks || [];
+      } catch (err) {
+        console.error('Failed to fetch tasks:', err);
+        return [];
+      }
+    },
+  });
+
+  return {
+    tasks: data ?? [],
+    isLoading,
+    isError,
+    error: error ?? null,
+    refetch,
+  };
+}
+
+/**
+ * 멘티 과제 생성 mutation 훅
+ */
+export function useCreateMenteeTask() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (taskData: { title: string; subject: string; date: string }) => {
+      const response = await axios.post('/tasks/mentee', taskData);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY_PREFIX });
+    },
+  });
+}
+
+/**
+ * 멘티 과제 수정 mutation 훅
+ */
+export function useUpdateMenteeTask() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ taskId, ...data }: { taskId: number; title?: string; subject?: string; date?: string }) => {
+      const response = await axios.patch(`/tasks/mentee/${taskId}`, data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY_PREFIX });
+    },
+  });
+}
+
+/**
+ * 멘티 과제 삭제 mutation 훅
+ */
+export function useDeleteMenteeTask() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (taskId: number) => {
+      await axios.delete(`/tasks/mentee/${taskId}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY_PREFIX });
+    },
+  });
+}
+
+/**
+ * 멘티 과제 완료 상태 변경 mutation 훅
+ */
+export function useUpdateMenteeTaskCompletion() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ taskId, isCompleted }: { taskId: number; isCompleted: boolean }) => {
+      await axios.patch(`/tasks/mentee/${taskId}/isCompleted`, { isCompleted });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY_PREFIX });
+    },
+  });
+}
+
+/**
+ * 멘티 과제 공부 시간 업데이트 mutation 훅
+ */
+export function useUpdateMenteeStudyTime() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ taskId, studyTime }: { taskId: number; studyTime: number }) => {
+      await axios.patch(`/tasks/mentee/${taskId}/studyTime`, { studyTime });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY_PREFIX });
+    },
+  });
+}
+
+/**
+ * 멘티 과제 코멘트 업데이트 mutation 훅
+ */
+export function useUpdateMenteeTaskComment() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ taskId, comment }: { taskId: number; comment: string }) => {
+      await axios.patch(`/tasks/mentee/${taskId}/comment`, { comment });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY_PREFIX });
+    },
+  });
+}

--- a/src/hooks/useNotificationStream.ts
+++ b/src/hooks/useNotificationStream.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+    import { useEffect } from 'react';
 import { useToastStore } from '../stores/toastStore';
 
 export const useNotificationStream = () => {

--- a/src/libs/types/mentor.ts
+++ b/src/libs/types/mentor.ts
@@ -24,6 +24,11 @@ export interface MentorTaskItem {
   title: string;
   images: MentorTaskImage[];
   feedback: MentorTaskFeedback;
+  subject?: string;
+  taskType?: string;
+  feedbackStatus?: 'PENDING' | 'COMPLETED';
+  createdAt?: string;
+  fileUrl?: string;
 }
 
 /** 페이지네이션된 과제 목록 */

--- a/src/pages/mentor/ArchivePage.tsx
+++ b/src/pages/mentor/ArchivePage.tsx
@@ -1,0 +1,353 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useToastStore } from '../../stores/toastStore';
+import SubmittedTaskModal from '../../components/feature/dashboard/SubmittedTaskModal';
+import { useMenteeList } from '../../hooks/useMenteeList';
+import { useMentorMenteeTasks } from '../../hooks/useMentorMenteeTasks';
+
+const MentorArchivePage = () => {
+  const navigate = useNavigate();
+  const [selectedTab, setSelectedTab] = useState<'reminder' | 'history'>('reminder');
+  const [selectedSubject, setSelectedSubject] = useState<string>('전체');
+  const [selectedMentee, setSelectedMentee] = useState<number | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<any>(null);
+  const addToast = useToastStore((state) => state.addToast);
+
+  // 멘티 목록 조회
+  const { menteeList, isLoading: isLoadingMentees } = useMenteeList();
+
+  // 선택된 멘티의 과제 목록 조회
+  const { tasks: tasksData, isLoading: isLoadingTasks } = useMentorMenteeTasks(selectedMentee, {
+    page: 0,
+    size: 100,
+    enabled: selectedMentee !== null,
+  });
+
+  const tasks = tasksData?.content || [];
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!searchQuery.trim()) return;
+
+    const foundMentee = menteeList.find(
+      (mentee) => mentee.name.toLowerCase().includes(searchQuery.toLowerCase())
+    );
+
+    if (foundMentee) {
+      setSelectedMentee(foundMentee.id);
+      addToast({
+        message: `${foundMentee.name} 학생을 선택했습니다.`,
+        type: 'success',
+      });
+    } else {
+      addToast({
+        message: '검색 결과가 없어요.\n학생의 이름을 다시 한번 확인해 주세요',
+        type: 'warning',
+      });
+    }
+  };
+
+  const handleFeedbackClick = (taskId: number) => {
+    const task = tasks.find((t) => t.taskId === taskId);
+    
+    if (selectedTab === 'history') {
+      // 과제 히스토리 탭: 모달 열기
+      if (task) {
+        setSelectedTask(task);
+        setIsModalOpen(true);
+      }
+    } else {
+      // 피드백 리마인드 탭: 페이지 이동
+      navigate(`/mentor/feedback?taskId=${taskId}`);
+    }
+  };
+
+  // 탭과 과목 필터에 따라 과제 필터링
+  const filteredTasks = tasks.filter((task) => {
+    // 탭 필터: 피드백 리마인드는 feedback이 없는 것만, 과제 히스토리는 feedback이 있는 것만
+    if (selectedTab === 'reminder' && task.feedback) {
+      return false;
+    }
+    if (selectedTab === 'history' && !task.feedback) {
+      return false;
+    }
+
+    // 과목 필터 (과제 히스토리 탭에서만)
+    if (selectedTab === 'history' && selectedSubject !== '전체') {
+      if (task.subject !== selectedSubject) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+
+  // 피드백 리마인드 개수 (feedback이 없는 과제)
+  const pendingFeedbackCount = tasks.filter((task) => !task.feedback).length;
+
+  // 현재 선택된 멘티 정보
+  const currentMentee = menteeList.find((m) => m.id === selectedMentee);
+
+  // 캐러셀에 표시할 멘티 (최대 3명)
+  const displayedMentees = menteeList.slice(0, 3);
+
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: '#F3F2FF' }}>
+      <div className="max-w-6xl mx-auto pl-16 pr-12 py-10">
+        {/* 검색창 */}
+        <div className="mb-10">
+          <form onSubmit={handleSearch} className="relative w-72">
+            <svg 
+              className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
+              fill="none" 
+              stroke="currentColor" 
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+            <input
+              type="text"
+              placeholder="멘티 검색..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full pl-11 pr-4 py-2 bg-white rounded-full text-sm border border-gray-100 focus:outline-none focus:ring-0"
+            />
+          </form>
+        </div>
+
+        {/* 헤더 */}
+        <div className="mb-3">
+          <div className="flex items-center gap-3 mb-2">
+            <svg className="w-7 h-7 text-gray-800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
+            </svg>
+            <h1 className="text-3xl font-bold text-gray-900">보관함</h1>
+          </div>
+          <p className="text-sm text-gray-500">
+            미작성 피드백을 확인하고 학생들의 학습 기록을 관리하세요.
+          </p>
+        </div>
+
+        {/* 멘티 캐러셀 */}
+        <div className="flex items-center gap-5 my-10">
+          <button className="shrink-0">
+            <svg className="w-6 h-6 text-purple-600" fill="currentColor" viewBox="0 0 12 12">
+              <path d="M8 2L3 6l5 4V2z" />
+            </svg>
+          </button>
+
+          <div className="flex gap-6 flex-1">
+            {isLoadingMentees ? (
+              <div className="flex-1 text-center py-8 text-gray-500">
+                멘티 목록을 불러오는 중...
+              </div>
+            ) : displayedMentees.length > 0 ? (
+              displayedMentees.map((mentee) => (
+                <div
+                  key={mentee.id}
+                  className={`flex-1 bg-white rounded-2xl p-5 flex flex-col items-center ring-1 cursor-pointer transition-all ${
+                    selectedMentee === mentee.id
+                      ? 'ring-purple-500 ring-2'
+                      : 'ring-gray-100'
+                  }`}
+                  onClick={() => setSelectedMentee(mentee.id)}
+                >
+                  <div 
+                    className="w-14 h-14 rounded-full flex items-center justify-center text-white text-lg font-semibold mb-2.5"
+                    style={{ backgroundColor: '#7C3AED' }}
+                  >
+                    {mentee.avatar}
+                  </div>
+                  <h3 className="text-sm font-bold text-gray-900 mb-0.5">{mentee.name}</h3>
+                  <p className="text-xs text-gray-500">{mentee.subject}</p>
+                </div>
+              ))
+            ) : (
+              <div className="flex-1 text-center py-8 text-gray-500">
+                등록된 멘티가 없습니다.
+              </div>
+            )}
+          </div>
+
+          <button className="shrink-0">
+            <svg className="w-6 h-6 text-purple-600" fill="currentColor" viewBox="0 0 12 12">
+              <path d="M4 2v8l5-4-5-4z" />
+            </svg>
+          </button>
+        </div>
+
+        {/* 탭 */}
+        <div className="flex items-center gap-4 mb-6">
+          <button
+            className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium ${
+              selectedTab === 'reminder'
+                ? 'bg-white border border-purple-500 text-purple-600'
+                : 'text-gray-600'
+            }`}
+            onClick={() => setSelectedTab('reminder')}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            피드백 리마인드
+            {selectedTab === 'reminder' && pendingFeedbackCount > 0 && (
+              <span className="ml-1 px-2 py-0.5 bg-red-500 text-white text-xs font-semibold rounded-full">
+                {pendingFeedbackCount}개
+              </span>
+            )}
+          </button>
+          <button 
+            className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium ${
+              selectedTab === 'history'
+                ? 'bg-white border border-purple-500 text-purple-600'
+                : 'text-gray-600'
+            }`}
+            onClick={() => setSelectedTab('history')}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            과제 히스토리
+          </button>
+        </div>
+
+        {/* 과목 필터 (과제 히스토리 탭일 때만 표시) */}
+        {selectedTab === 'history' && (
+          <div className="flex gap-3 mb-8">
+            {['전체', '국어', '수학', '영어'].map((subject) => (
+              <button
+                key={subject}
+                className={`px-4 py-2 rounded-full text-sm font-medium ${
+                  selectedSubject === subject
+                    ? 'text-white'
+                    : 'bg-white text-gray-600'
+                }`}
+                style={
+                  selectedSubject === subject
+                    ? { backgroundColor: '#7C3AED' }
+                    : {}
+                }
+                onClick={() => setSelectedSubject(subject)}
+              >
+                {subject}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* 과제 카드 */}
+        <div className="grid grid-cols-2 gap-6">
+          {isLoadingTasks ? (
+            <div className="col-span-2 flex flex-col items-center justify-center py-20">
+              <div className="text-gray-500">과제 목록을 불러오는 중...</div>
+            </div>
+          ) : selectedMentee && filteredTasks.length > 0 ? (
+            filteredTasks.map((task) => (
+            <div
+              key={task.taskId}
+              className="bg-white rounded-2xl p-7 ring-1 ring-gray-100"
+            >
+              {/* 과목 pill */}
+              <div className="mb-3">
+                <span className="inline-block px-3 py-1 rounded-full text-xs font-semibold bg-green-100 text-green-600">
+                  {task.subject || '과목'}
+                </span>
+              </div>
+
+              {/* 과제명 */}
+              <h3 className="text-base font-bold text-gray-900 mb-4">{task.title}</h3>
+
+              {/* 날짜 pill */}
+              {task.createdAt && (
+                <div className="mb-5">
+                  <span 
+                    className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium text-white"
+                    style={{ backgroundColor: '#7C3AED' }}
+                  >
+                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                    {new Date(task.createdAt).toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })}
+                  </span>
+                </div>
+              )}
+
+              {/* 하단 정보 */}
+              <div className="space-y-1 mb-3">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-gray-600">
+                    {task.createdAt ? new Date(task.createdAt).toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\. /g, '.').replace('.', '') : ''}
+                  </span>
+                  {selectedTab === 'reminder' && (
+                    <span className="text-gray-500">
+                      {task.feedbackStatus === 'COMPLETED' ? '완료' : '대기중'}
+                    </span>
+                  )}
+                </div>
+                {currentMentee && (
+                  <div className="text-xs text-gray-500">
+                    {currentMentee.name} · {currentMentee.subject}
+                  </div>
+                )}
+              </div>
+
+              {/* 액션 버튼 */}
+              <div className="text-right">
+                <button 
+                  className="text-xs font-medium text-purple-600 hover:text-purple-700 inline-flex items-center gap-1"
+                  onClick={() => handleFeedbackClick(task.taskId)}
+                >
+                  {selectedTab === 'reminder' ? '피드백 작성하기' : '피드백 확인하기'}
+                  <svg className="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 12 12">
+                    <path d="M4 2v8l5-4-5-4z" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          ))
+          ) : (
+            <div className="col-span-2 flex flex-col items-center justify-center py-20">
+              <svg className="w-16 h-16 text-gray-300 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              <p className="text-gray-500 font-medium mb-1">
+                {selectedMentee ? '모든 피드백을 작성했어요!' : '모든 피드백을 작성했어요!'}
+              </p>
+              <p className="text-sm text-gray-400">
+                {selectedMentee ? '학생이 이름을 검색해 과제를 확인하세요' : '학생의 이름을 지금 바로 검색해보세요'}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 제출 과제 조회 모달 */}
+      {selectedTask && (
+        <SubmittedTaskModal
+          isOpen={isModalOpen}
+          onClose={() => {
+            setIsModalOpen(false);
+            setSelectedTask(null);
+          }}
+          task={{
+            id: selectedTask.taskId,
+            title: selectedTask.title,
+            subject: selectedTask.subject || '과목',
+            date: selectedTask.createdAt ? new Date(selectedTask.createdAt).toLocaleDateString('ko-KR') : '',
+            studyTime: '학습 시간 정보 없음',
+            images: selectedTask.images?.map((img: any) => img.url) || [],
+            comment: selectedTask.feedback?.comment,
+            feedback: selectedTask.feedback ? {
+              summary: selectedTask.feedback.summary,
+              detail: selectedTask.feedback.comment,
+            } : undefined,
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default MentorArchivePage;

--- a/src/pages/review/ReviewPage.tsx
+++ b/src/pages/review/ReviewPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useMenteeFeedbacks } from '../../hooks/useMenteeFeedbacks';
 import FeedbackCard from '../../components/feature/review/FeedbackCard';
 import FeedbackDetailModal from '../../components/feature/review/FeedbackDetailModal';
 import '../../styles/pages/review.css';
@@ -7,22 +8,22 @@ const ReviewPage = () => {
   const [activeTab, setActiveTab] = useState<'feedback' | 'history'>('feedback');
   const [selectedFeedback, setSelectedFeedback] = useState<number | null>(null);
 
-  // 임시 데이터 (추후 API 연동)
-  const feedbacks = [
-    {
-      id: 1,
-      subject: '영어',
-      title: '단어 시험 (Day 15)',
-      fileName: 'Day15_Word_Test.pdf',
-      fileSize: '2.1MB',
-      score: 45,
-      mentorPick: true,
-      date: '2025년 2월 5일',
-      mentorName: '김영희',
-      mentorComment: '단어 암기를 정말 열심히 하셨네요! 특히 Day 15의 어려운 단어들을 잘 소화하신 것 같습니다.\n\n다만 몇 가지 철자 실수가 있었어요:\n- "receive"를 "recieve"로 쓰신 부분\n- "separate"를 "seperate"로 쓰신 부분\n\n이런 헷갈리는 철자는 따로 노트에 정리해서 반복 학습하시면 좋을 것 같아요. 전체적으로 잘하고 계십니다. 화이팅!',
-      imageUrl: '',
-    },
-  ];
+  // 피드백 목록 조회
+  const { feedbacks: feedbacksData, isLoading } = useMenteeFeedbacks();
+
+  const feedbacks = feedbacksData.map((fb) => ({
+    id: fb.feedbackId,
+    subject: fb.subject || '과목',
+    title: fb.taskTitle,
+    fileName: '',
+    fileSize: '',
+    score: 0,
+    mentorPick: false,
+    date: fb.createdAt ? new Date(fb.createdAt).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' }) : '',
+    mentorName: '멘토',
+    mentorComment: fb.comment || fb.summary,
+    imageUrl: '',
+  }));
 
   const handleViewFeedback = (feedbackId: number) => {
     setSelectedFeedback(feedbackId);
@@ -32,7 +33,7 @@ const ReviewPage = () => {
     setSelectedFeedback(null);
   };
 
-  const currentFeedback = feedbacks.find(f => f.id === selectedFeedback);
+  const currentFeedback = feedbacks.find((f: { id: number }) => f.id === selectedFeedback);
 
   return (
     <>
@@ -73,7 +74,11 @@ const ReviewPage = () => {
         {/* 컨텐츠 */}
         {activeTab === 'feedback' ? (
           <div className="feedback-list">
-            {feedbacks.length === 0 ? (
+            {isLoading ? (
+              <div className="empty-state">
+                <p className="empty-title">로딩 중...</p>
+              </div>
+            ) : feedbacks.length === 0 ? (
               <div className="empty-state">
                 <svg className="empty-icon" width="80" height="80" viewBox="0 0 80 80" fill="none">
                   <rect x="20" y="15" width="40" height="50" rx="2" stroke="#D1D5DB" strokeWidth="3"/>
@@ -86,7 +91,19 @@ const ReviewPage = () => {
               </div>
             ) : (
               <div className="feedback-grid">
-                {feedbacks.map((feedback) => (
+                {feedbacks.map((feedback: {
+                  id: number;
+                  subject: string;
+                  title: string;
+                  fileName: string;
+                  fileSize: string;
+                  score: number;
+                  mentorPick: boolean;
+                  date: string;
+                  mentorName: string;
+                  mentorComment: string;
+                  imageUrl: string;
+                }) => (
                   <FeedbackCard 
                     key={feedback.id} 
                     {...feedback} 

--- a/src/styles/pages/mentor-archive.css
+++ b/src/styles/pages/mentor-archive.css
@@ -1,0 +1,333 @@
+/* 멘토 보관함 페이지 */
+.mentor-archive-page {
+  width: 100%;
+  min-height: 100vh;
+  background-color: #F5F5F5;
+  padding: 32px 40px;
+}
+
+/* 검색 섹션 */
+.search-section {
+  margin-bottom: 32px;
+}
+
+.search-input-wrapper {
+  position: relative;
+  max-width: 400px;
+}
+
+.search-input-wrapper svg {
+  position: absolute;
+  left: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #9CA3AF;
+}
+
+.search-input-wrapper input {
+  width: 100%;
+  padding: 12px 16px 12px 48px;
+  border: 1px solid #E5E7EB;
+  border-radius: 12px;
+  font-size: 14px;
+  background: white;
+}
+
+.search-input-wrapper input:focus {
+  outline: none;
+  border-color: #6366F1;
+}
+
+/* 페이지 헤더 */
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.page-header svg {
+  color: #111827;
+}
+
+.page-header h1 {
+  font-size: 28px;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+.page-description {
+  font-size: 14px;
+  color: #6B7280;
+  margin-bottom: 32px;
+}
+
+/* 멘티 캐러셀 */
+.mentee-carousel {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 32px;
+}
+
+.carousel-arrow {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: white;
+  border: 1px solid #E5E7EB;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.carousel-arrow:hover {
+  background: #F9FAFB;
+}
+
+.carousel-arrow svg {
+  color: #6B7280;
+}
+
+.mentee-cards {
+  display: flex;
+  gap: 16px;
+  overflow-x: auto;
+  flex: 1;
+  padding: 8px 0;
+}
+
+.mentee-card {
+  background: white;
+  border-radius: 16px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  min-width: 160px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.mentee-card:hover {
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+}
+
+.mentee-avatar {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #667EEA 0%, #764BA2 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.mentee-info {
+  text-align: center;
+}
+
+.mentee-info h3 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 4px 0;
+}
+
+.mentee-info p {
+  font-size: 13px;
+  color: #6B7280;
+  margin: 0;
+}
+
+/* 탭 컨테이너 */
+.tabs-container {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.tab {
+  padding: 12px 20px;
+  background: white;
+  border: 1px solid #E5E7EB;
+  border-radius: 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #6B7280;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tab:hover {
+  background: #F9FAFB;
+}
+
+.tab.active {
+  background: #6366F1;
+  color: white;
+  border-color: #6366F1;
+}
+
+.tab svg {
+  width: 20px;
+  height: 20px;
+}
+
+.tab-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 8px;
+  background-color: #EF4444;
+  color: white;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.tab.active .tab-badge {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
+/* 컨텐츠 영역 */
+.content-area {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+/* 과제 카드 */
+.task-card {
+  background: white;
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s;
+  border: 2px solid transparent;
+}
+
+.task-card:hover {
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+}
+
+.task-card.pink {
+  border-color: #FDE2E4;
+}
+
+.task-card.green {
+  border-color: #D1FAE5;
+}
+
+.task-card-header {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
+.task-badge {
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.task-badge.pink {
+  background-color: #FDE2E4;
+  color: #E11D48;
+}
+
+.task-badge.green {
+  background-color: #D1FAE5;
+  color: #059669;
+}
+
+.task-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #111827;
+  margin: 0 0 12px 0;
+}
+
+.task-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.task-time {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #6B7280;
+}
+
+.task-time svg {
+  color: #9CA3AF;
+}
+
+.task-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 12px;
+  border-top: 1px solid #F3F4F6;
+  margin-bottom: 16px;
+}
+
+.task-date {
+  font-size: 13px;
+  color: #6B7280;
+}
+
+.task-subject {
+  font-size: 13px;
+  color: #6B7280;
+}
+
+.task-action-btn {
+  width: 100%;
+  padding: 10px;
+  background: #F9FAFB;
+  border: 1px solid #E5E7EB;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  color: #6366F1;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.task-action-btn:hover {
+  background: #6366F1;
+  color: white;
+  border-color: #6366F1;
+}
+
+/* 반응형 */
+@media (max-width: 1024px) {
+  .mentor-archive-page {
+    padding: 20px;
+  }
+
+  .content-area {
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  }
+}


### PR DESCRIPTION

## Issue
>- close [#42 ]

## Task
- 멘토 보관함 페이지 UI 구현 (디자인 1:1 매칭)
  - 멘티 검색 기능
  - 멘티 캐러셀 (3명 표시, 선택 가능)
  - 피드백 리마인드 / 과제 히스토리 탭
  - 과목 필터 (과제 히스토리 탭)
  - 제출 과제 조회 모달

- API 연동
  - useMenteeList: 멘티 목록 조회
  - useMentorMenteeTasks: 멘티별 과제 목록 조회
  - 피드백 상태별 필터링 (feedback 유무)

- 공통 Hooks 추가
  - useMenteeTasks: 멘티 과제 CRUD
  - useMenteeFeedbacks: 멘티 피드백 조회
  - useUnreadFeedbackCount: 안 읽은 피드백 개수

- 기타 페이지 API 연동
  - MenteeDashboardPage: 과제 목록 및 CRUD
  - ReviewPage: 피드백 목록 조회
  - MentorDashboardPage: 대시보드 통계

- App.tsx 라우팅 설정
  - /mentor/archive 경로 추가
  - NotificationToasts를 BrowserRouter 내부로 이동

## ScreenShot

## to Reviewer
이렇게 보시는게 더 괜찮을 것 같네욥. 요약해서 보실려면 이슈들어가주세요.